### PR TITLE
FFS-2183: Oppgrader mapping-service til web-resource-server 4.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
-    implementation("no.novari:flyt-web-resource-server:3.2.0")
+    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-1")
     implementation("no.novari:flyt-kafka:7.2.0")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
-    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-3")
+    implementation("no.novari:flyt-web-resource-server:4.0.0")
     implementation("no.novari:flyt-kafka:7.2.0")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
-    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-2")
+    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-3")
     implementation("no.novari:flyt-kafka:7.2.0")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
-    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-1")
+    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-2")
     implementation("no.novari:flyt-kafka:7.2.0")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")


### PR DESCRIPTION
## Summary

Implements [FFS-2183](https://novari-iks.atlassian.net/browse/FFS-2183).

- Oppgraderer til `flyt-web-resource-server:4.0.0`.
- Beholder eksisterende roller og interne API-er.

[FFS-2183]: https://novari-iks.atlassian.net/browse/FFS-2183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ