### PR TITLE
FFS-2233 Add OpenTelemetry tracing rollout

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,9 +42,12 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
+    runtimeOnly("net.logstash.logback:logstash-logback-encoder:9.0")
 
-    implementation("no.novari:flyt-web-resource-server:4.0.0")
-    implementation("no.novari:flyt-kafka:7.2.0")
+    implementation("no.novari:flyt-web-resource-server:4.1.0-rc-2")
+    implementation("no.novari:flyt-kafka:7.3.0-rc-2")
+    implementation("no.novari:telemetry-starter:0.0.4")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     kapt("org.springframework.boot:spring-boot-configuration-processor")

--- a/kustomize/overlays/afk-no/api/kustomization.yaml
+++ b/kustomize/overlays/afk-no/api/kustomization.yaml
@@ -23,6 +23,11 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "afk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "afk.no"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -23,6 +23,16 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "afk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "afk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/agderfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/api/kustomization.yaml
@@ -23,6 +23,11 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "agderfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "agderfk.no"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/agderfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/beta/kustomization.yaml
@@ -23,6 +23,16 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "agderfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "agderfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/bfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/api/kustomization.yaml
@@ -23,6 +23,11 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "bfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "bfk.no"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -23,6 +23,16 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "bfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "bfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
+++ b/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
@@ -23,6 +23,11 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "bym-oslo-kommune-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "bym.oslo.kommune.no"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/ffk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/api/kustomization.yaml
@@ -23,6 +23,11 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "ffk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "ffk.no"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/ffk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/beta/kustomization.yaml
@@ -23,6 +23,16 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "ffk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "ffk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
+++ b/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
@@ -23,6 +23,16 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "fintlabs-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "fintlabs.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
@@ -23,6 +23,11 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "innlandetfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "innlandetfylke.no"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
@@ -23,6 +23,16 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "innlandetfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "innlandetfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/mrfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/mrfylke-no/api/kustomization.yaml
@@ -23,6 +23,11 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "mrfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "mrfylke.no"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/nfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/nfk-no/api/kustomization.yaml
@@ -23,6 +23,11 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "nfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "nfk.no"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/ofk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/api/kustomization.yaml
@@ -23,6 +23,11 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "ofk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "ofk.no"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -23,6 +23,16 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "ofk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "ofk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/rogfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/api/kustomization.yaml
@@ -23,6 +23,11 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "rogfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "rogfk.no"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/rogfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/beta/kustomization.yaml
@@ -23,6 +23,16 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "rogfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "rogfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
@@ -23,6 +23,11 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "telemarkfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "telemarkfylke.no"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
@@ -23,6 +23,16 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "telemarkfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "telemarkfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
@@ -23,6 +23,11 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "tromsfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "tromsfylke.no"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
@@ -23,6 +23,16 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "tromsfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "tromsfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
@@ -23,6 +23,11 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "trondelagfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "trondelagfylke.no"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
@@ -23,6 +23,16 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "trondelagfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "trondelagfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
@@ -23,6 +23,11 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "vestfoldfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "vestfoldfylke.no"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
@@ -23,6 +23,16 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "vestfoldfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "vestfoldfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/vlfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/api/kustomization.yaml
@@ -23,6 +23,11 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "vlfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "vlfk.no"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/overlays/vlfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/beta/kustomization.yaml
@@ -23,6 +23,16 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "vlfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "vlfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/kustomize/templates/overlay.yaml.tpl
+++ b/kustomize/templates/overlay.yaml.tpl
@@ -23,6 +23,11 @@ patches:
         value:
           name: "novari.kafka.topic.orgId"
           value: "$FINT_KAFKA_TOPIC_ORGID"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "$ORG_ID"$OTEL_EXPORTER_OTLP_ENDPOINT_PATCH
     target:
       kind: Application
       name: fint-flyt-mapping-service

--- a/scripts/render-overlay.sh
+++ b/scripts/render-overlay.sh
@@ -52,8 +52,18 @@ while IFS= read -r file; do
   export APP_INSTANCE="fint-flyt-mapping-service_${namespace//-/_}"
   export KAFKA_TOPIC="${namespace}.flyt.*"
   export FINT_KAFKA_TOPIC_ORGID="$namespace"
+  export OTEL_EXPORTER_OTLP_ENDPOINT_PATCH=""
+
+  if [[ "$env_name" == "beta" ]]; then
+    OTEL_EXPORTER_OTLP_ENDPOINT_PATCH='
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"'
+  fi
 
   tmp="$(mktemp)"
-  envsubst '$NAMESPACE $ORG_ID $APP_INSTANCE $KAFKA_TOPIC $FINT_KAFKA_TOPIC_ORGID' < "$template" > "$tmp"
+  envsubst '$NAMESPACE $ORG_ID $APP_INSTANCE $KAFKA_TOPIC $FINT_KAFKA_TOPIC_ORGID $OTEL_EXPORTER_OTLP_ENDPOINT_PATCH' < "$template" > "$tmp"
   mv "$tmp" "$file"
 done < <(find "$ROOT/kustomize/overlays" -name kustomization.yaml -print | sort)

--- a/src/main/kotlin/no/novari/flyt/mapping/kafka/InstanceRegisteredEventConsumerConfiguration.kt
+++ b/src/main/kotlin/no/novari/flyt/mapping/kafka/InstanceRegisteredEventConsumerConfiguration.kt
@@ -1,5 +1,6 @@
 package no.novari.flyt.mapping.kafka
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.flyt.kafka.instanceflow.consuming.InstanceFlowConsumerRecord
 import no.novari.flyt.kafka.instanceflow.consuming.InstanceFlowErrorHandlerConfiguration
 import no.novari.flyt.kafka.instanceflow.consuming.InstanceFlowErrorHandlerFactory
@@ -12,18 +13,17 @@ import no.novari.kafka.consuming.ListenerConfiguration
 import no.novari.kafka.topic.name.EventTopicNameParameters
 import no.novari.kafka.topic.name.TopicNamePrefixParameters
 import org.apache.kafka.clients.consumer.ConsumerRecord
-import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
 import org.springframework.kafka.listener.ListenerExecutionFailedException
 
+private val log = KotlinLogging.logger {}
+
 @Configuration
 class InstanceRegisteredEventConsumerConfiguration(
     private val consumerProperties: KafkaConsumerProperties,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
-
     @Bean
     fun instanceRegisteredEventConsumer(
         factoryService: InstanceFlowListenerFactoryService,
@@ -111,7 +111,7 @@ class InstanceRegisteredEventConsumerConfiguration(
                         exception: Exception,
                     ) {
                         val unwrappedException = unwrapException(exception)
-                        log.debug("{} handled using publishGeneralSystemErrorEvent", unwrappedException.javaClass)
+                        log.debug { "${unwrappedException.javaClass} handled using publishGeneralSystemErrorEvent" }
                         errorEventProducerService.publishGeneralSystemErrorEvent(
                             instanceFlowConsumerRecord.instanceFlowHeaders,
                         )
@@ -121,7 +121,7 @@ class InstanceRegisteredEventConsumerConfiguration(
                         consumerRecord: ConsumerRecord<String, InstanceObject>,
                         exception: Exception,
                     ) {
-                        log.warn("Missing headers on record, skipping", exception)
+                        log.warn(exception) { "Missing headers on record, skipping" }
                     }
                 },
             ).skipRecordOnRecoveryFailure()

--- a/src/main/resources/application-flyt-kafka.yaml
+++ b/src/main/resources/application-flyt-kafka.yaml
@@ -3,6 +3,8 @@ novari:
     topic:
       domain-context: flyt
     application-id: ${fint.application-id}
+    tracing:
+      enabled: true
 
 spring:
   kafka:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,6 +16,8 @@ logging:
     no.novari.cache.ehcache.FintEhCacheEventLogger: WARN
 
 spring:
+  application:
+    name: ${fint.application-id}
   profiles:
     include:
       - flyt-kafka

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,8 @@
+<configuration scan="true">
+
+    <include resource="no/novari/telemetry/logback-json.xml"/>
+
+    <root level="INFO">
+        <appender-ref ref="TELEMETRY_JSON"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary

- Add `no.novari:telemetry-starter:0.0.4` and bump `flyt-web-resource-server`/`flyt-kafka` to the verified tracing-enabled versions.
- Set `spring.application.name`, enable Kafka tracing, and wire telemetry JSON logging with trace/span fields.
- Extend the overlay generator to emit `novari.telemetry.org-id` for all overlays and `OTEL_EXPORTER_OTLP_ENDPOINT` only for beta overlays, then regenerate overlays from the template.
- Convert the existing SLF4J logger usage to kotlin-logging.

## Validation

- `kustomize build` for all overlays
- `./gradlew check`

Jira: https://novari-iks.atlassian.net/browse/FFS-2233